### PR TITLE
Update userHandler.js

### DIFF
--- a/server/handlers/apiHandlers/userHandler.js
+++ b/server/handlers/apiHandlers/userHandler.js
@@ -39,7 +39,7 @@ exports.addPossibleEvent = (req, res) => {
 };
 
 exports.getAllMatches = (req, res) => {
-  db.tx(t=>{
+  db.task(t=>{
     return t.possibles.getPossibles({userId: +req.params.userId})
      .then(possibles => {
        return t.batch(possibles.map(p => {


### PR DESCRIPTION
must not over-use transactions, and certainly not use them when just reading data. transactions are locking, and thus blocking operations, i.e. they are expensive, must be used only where absolutely necessary.